### PR TITLE
Create (empty) db folder

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -60,6 +60,9 @@ DjangoGenerator.prototype.app = function app() {
   this.mkdir('bin');
   this.mkdir('libs');
 
+  // Dev db folder
+  this.mkdir('db');
+
   // Templates folder.
   this.mkdir('templates');
   this.mkdir('templates/layout');


### PR DESCRIPTION
Development settings point to a "db" folder which does not exist, so running the server straight causes an error.